### PR TITLE
Allow empty "name" parameter for UUID versions 3 and 5.

### DIFF
--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -148,9 +148,6 @@ class GenerateCommand extends Command
             case 3:
             case 5:
                 $ns = $this->validateNamespace($namespace);
-                if (empty($name)) {
-                    throw new Exception('The name argument is required for version 3 or 5 UUIDs');
-                }
                 if ($version == 3) {
                     $uuid = Uuid::uuid3($ns, $name);
                 } else {

--- a/tests/Command/GenerateCommandTest.php
+++ b/tests/Command/GenerateCommandTest.php
@@ -381,8 +381,6 @@ class GenerateCommandTest extends TestCase
      * @covers Ramsey\Uuid\Console\Command\GenerateCommand::execute
      * @covers Ramsey\Uuid\Console\Command\GenerateCommand::createUuid
      * @covers Ramsey\Uuid\Console\Command\GenerateCommand::validateNamespace
-     * @expectedException \Ramsey\Uuid\Console\Exception
-     * @expectedExceptionMessage The name argument is required for version 3 or 5 UUIDs
      */
     public function testExecuteForUuidSpecifyVersion3WithoutName()
     {
@@ -394,6 +392,14 @@ class GenerateCommandTest extends TestCase
         $output = new TestOutput();
 
         $this->execute->invoke($generate, $input, $output);
+
+        $this->assertCount(1, $output->messages);
+
+        foreach ($output->messages as $uuid) {
+            $this->assertTrue(Uuid::isValid($uuid));
+            $this->assertEquals(3, Uuid::fromString($uuid)->getVersion());
+            $this->assertEquals('c87ee674-4ddc-3efe-a74e-dfe25da5d7b3', $uuid);
+        }
     }
 
     /**
@@ -554,8 +560,6 @@ class GenerateCommandTest extends TestCase
      * @covers Ramsey\Uuid\Console\Command\GenerateCommand::execute
      * @covers Ramsey\Uuid\Console\Command\GenerateCommand::createUuid
      * @covers Ramsey\Uuid\Console\Command\GenerateCommand::validateNamespace
-     * @expectedException \Ramsey\Uuid\Console\Exception
-     * @expectedExceptionMessage The name argument is required for version 3 or 5 UUIDs
      */
     public function testExecuteForUuidSpecifyVersion5WithoutName()
     {
@@ -567,6 +571,14 @@ class GenerateCommandTest extends TestCase
         $output = new TestOutput();
 
         $this->execute->invoke($generate, $input, $output);
+
+        $this->assertCount(1, $output->messages);
+
+        foreach ($output->messages as $uuid) {
+            $this->assertTrue(Uuid::isValid($uuid));
+            $this->assertEquals(5, Uuid::fromString($uuid)->getVersion());
+            $this->assertEquals('4ebd0208-8328-5d69-8c44-ec50939c0967', $uuid);
+        }
     }
 
     /**


### PR DESCRIPTION
[RFC4122](https://tools.ietf.org/html/rfc4122#section-4.3) doesn't mention anything about empty "name" parameter not being allowed for UUID v3 and v5. An empty string may be useful in some scenarios.

If having empty string accepted is too much of a stretch, I could resubmit the PR keeping the current behaviour for empty strings, but accepting string representation of zero ("0").

Closes #1.