### PR TITLE
Add support for symfony/console v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - nightly
 
 sudo: false
 
@@ -20,9 +20,11 @@ matrix:
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
     - php: 7.1
       env: COMPOSER_FLAGS='--prefer-latest'
-    - php: hhvm
+    - php: nightly
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
   fast_finish: true
+  allow_failures:
+    - php: nightly
 
 before_install:
   - travis_retry composer self-update
@@ -38,19 +40,13 @@ install:
 
   - travis_retry composer update $COMPOSER_FLAGS --prefer-source
 
-script:
+before_script:
   - mkdir -p build/logs
+
+script:
   - ./vendor/bin/parallel-lint src tests
-  - ./vendor/bin/phpunit --verbose
+  - ./vendor/bin/phpunit --verbose --coverage-clover build/logs/clover.xml
   - ./vendor/bin/phpcs src tests --standard=psr2 -sp
 
 after_script:
-  - php vendor/bin/coveralls
-
-notifications:
-  webhooks:
-    urls:
-      - 'https://webhooks.gitter.im/e/f3356db3405001e47b5e'
-    on_success: change
-    on_failure: always
-    on_start: false
+  - travis_retry php vendor/bin/coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 sudo: false
@@ -17,12 +18,24 @@ matrix:
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
     - php: 7.0
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+    - php: 7.1
+      env: COMPOSER_FLAGS='--prefer-latest'
     - php: hhvm
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
   fast_finish: true
 
-before_script:
+before_install:
   - travis_retry composer self-update
+
+install:
+  - |
+    if [[ "$COMPOSER_FLAGS" == "--prefer-latest" ]]; then
+        composer config minimum-stability dev
+        composer config prefer-stable false
+
+        export COMPOSER_FLAGS=""
+    fi;
+
   - travis_retry composer update $COMPOSER_FLAGS --prefer-source
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ sudo: false
 
 matrix:
   include:
+    - php: 5.4
+      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
     - php: 5.5
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
     - php: 5.6
@@ -19,9 +21,21 @@ matrix:
     - php: 7.0
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
     - php: 7.1
-      env: COMPOSER_FLAGS='--prefer-latest'
+      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
     - php: nightly
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+    - php: 5.4
+      env: COMPOSER_FLAGS='--prefer-latest'
+    - php: 5.5
+      env: COMPOSER_FLAGS='--prefer-latest'
+    - php: 5.6
+      env: COMPOSER_FLAGS='--prefer-latest'
+    - php: 7.0
+      env: COMPOSER_FLAGS='--prefer-latest'
+    - php: 7.1
+      env: COMPOSER_FLAGS='--prefer-latest'
+    - php: nightly
+      env: COMPOSER_FLAGS='--prefer-latest'
   fast_finish: true
   allow_failures:
     - php: nightly

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=5.4",
         "ramsey/uuid": "^3.0",
-        "symfony/console": "^2.7|~3.0",
+        "symfony/console": "^2.7|~3.0|^4.0",
         "moontoast/math": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
Symfony 4 is still in beta at the moment, which requires the need for the minimum stability (for testing only).