### PR TITLE
Support PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "moontoast/math": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.7|^5.0",
+        "phpunit/phpunit": "^4.8.35|^5.7|^6.4",
         "squizlabs/php_codesniffer": "^2.3",
         "jakub-onderka/php-parallel-lint": "^0.9.0",
         "satooshi/php-coveralls": "^0.6.1"

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,8 @@
 <?php
 namespace Ramsey\Uuid\Console;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
 {
 }


### PR DESCRIPTION
I added `PHPUnit 6` support.

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02) that support the `PHPUnit\Framework\TestCase` namespace.