### PR TITLE
Add exit code to commands

### DIFF
--- a/src/Command/DecodeCommand.php
+++ b/src/Command/DecodeCommand.php
@@ -82,6 +82,8 @@ class DecodeCommand extends Command
         (new UuidFormatter())->write($table, $uuid);
 
         $table->render($output);
+
+        return 0;
     }
 
     protected function createTable(OutputInterface $output)

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -125,6 +125,8 @@ class GenerateCommand extends Command
         foreach ($uuids as $uuid) {
             $output->writeln((string) $uuid);
         }
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
`synfony/console:^5.0` throws an exception if `Command::execute()` does not return a integer exit code.

This returns `0` from the encode and decode commands.