### PR TITLE
Return a SUCCESS code to prevent a TypeError

### DIFF
--- a/src/Command/DecodeCommand.php
+++ b/src/Command/DecodeCommand.php
@@ -82,6 +82,8 @@ class DecodeCommand extends Command
         (new UuidFormatter())->write($table, $uuid);
 
         $table->render($output);
+
+        return self::SUCCESS;
     }
 
     protected function createTable(OutputInterface $output)

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -125,6 +125,8 @@ class GenerateCommand extends Command
         foreach ($uuids as $uuid) {
             $output->writeln((string) $uuid);
         }
+
+        return self::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
When I tried running this today using PHP 7.4, I noticed that the Symfony console component was returning a TypeError due to the void returns from the `execute()` methods. I've updated them both to `return self::SUCCESS;` to prevent this error.