### PR TITLE
feat: support uuid6 if it's available

### DIFF
--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -43,7 +43,7 @@ class GenerateCommand extends Command
                 'version',
                 InputArgument::OPTIONAL,
                 'The UUID version to generate. Supported are version "1", "3", '
-                . '"4" and "5".',
+                . '"4", "5" and "6".',
                 1
             )
             ->addArgument(
@@ -156,8 +156,14 @@ class GenerateCommand extends Command
                     $uuid = Uuid::uuid5($ns, $name);
                 }
                 break;
+            case 6:
+                if (!method_exists('\Ramsey\Uuid\Uuid', 'uuid6')) {
+                    throw new Exception('Your version of ramsey/uuid don\'t support uuid6.');
+                }
+                $uuid = Uuid::uuid6();
+                break;
             default:
-                throw new Exception('Invalid UUID version. Supported are version "1", "3", "4", and "5".');
+                throw new Exception('Invalid UUID version. Supported are version "1", "3", "4", "5" and "6".');
         }
 
         return $uuid;

--- a/tests/Command/GenerateCommandTest.php
+++ b/tests/Command/GenerateCommandTest.php
@@ -247,6 +247,120 @@ class GenerateCommandTest extends TestCase
     /**
      * @covers Ramsey\Uuid\Console\Command\GenerateCommand::execute
      * @covers Ramsey\Uuid\Console\Command\GenerateCommand::createUuid
+     */
+    public function testExecuteForUuidSpecifyVersion6()
+    {
+        if (!method_exists('\Ramsey\Uuid\Uuid', 'uuid6')) {
+            $this->markTestSkipped('Not supported version of ramsey/uuid');
+        }
+
+        $generate = new GenerateCommand();
+
+        $input = new StringInput('6');
+        $input->bind($generate->getDefinition());
+
+        $output = new TestOutput();
+
+        $execute = new \ReflectionMethod('Ramsey\\Uuid\\Console\\Command\\GenerateCommand', 'execute');
+        $execute->setAccessible(true);
+
+        $execute->invoke($generate, $input, $output);
+
+        $this->assertCount(1, $output->messages);
+        $this->assertTrue(Uuid::isValid($output->messages[0]));
+        $this->assertEquals(6, Uuid::fromString($output->messages[0])->getVersion());
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Console\Command\GenerateCommand::execute
+     * @covers Ramsey\Uuid\Console\Command\GenerateCommand::createUuid
+     */
+    public function testExecuteForUuidSpecifyVersion6WithCount()
+    {
+        if (!method_exists('\Ramsey\Uuid\Uuid', 'uuid6')) {
+            $this->markTestSkipped('Not supported version of ramsey/uuid');
+        }
+        $generate = new GenerateCommand();
+
+        //
+        // Test using the "-c" option
+        //
+
+        $input1 = new StringInput('6 -c 3');
+        $input1->bind($generate->getDefinition());
+
+        $output1 = new TestOutput();
+
+        $execute = new \ReflectionMethod('Ramsey\\Uuid\\Console\\Command\\GenerateCommand', 'execute');
+        $execute->setAccessible(true);
+
+        $execute->invoke($generate, $input1, $output1);
+
+        $this->assertCount(3, $output1->messages);
+
+        foreach ($output1->messages as $uuid) {
+            $this->assertTrue(Uuid::isValid($uuid));
+            $this->assertEquals(6, Uuid::fromString($uuid)->getVersion());
+        }
+
+        //
+        // Test using the "--count" option
+        //
+
+        $input2 = new StringInput('6 --count=8');
+        $input2->bind($generate->getDefinition());
+
+        $output2 = new TestOutput();
+
+        $execute = new \ReflectionMethod('Ramsey\\Uuid\\Console\\Command\\GenerateCommand', 'execute');
+        $execute->setAccessible(true);
+
+        $execute->invoke($generate, $input2, $output2);
+
+        $this->assertCount(8, $output2->messages);
+
+        foreach ($output2->messages as $uuid) {
+            $this->assertTrue(Uuid::isValid($uuid));
+            $this->assertEquals(6, Uuid::fromString($uuid)->getVersion());
+        }
+    }
+
+
+    /**
+     * @covers Ramsey\Uuid\Console\Command\GenerateCommand::execute
+     * @covers Ramsey\Uuid\Console\Command\GenerateCommand::createUuid
+     */
+    public function testExecuteForUuidSpecifyVersion6OnUnsupportedVersion()
+    {
+        if (!method_exists($this, 'expectException')) {
+            $this->markTestSkipped('This version of PHPUnit does not have expectException()');
+        }
+        if (method_exists('\Ramsey\Uuid\Uuid', 'uuid6')) {
+            $this->markTestSkipped('Not supported version of ramsey/uuid');
+        }
+        $generate = new GenerateCommand();
+
+        //
+        // Test using the "-c" option
+        //
+
+        $input1 = new StringInput('6');
+        $input1->bind($generate->getDefinition());
+
+        $output1 = new TestOutput();
+
+        $execute = new \ReflectionMethod('Ramsey\\Uuid\\Console\\Command\\GenerateCommand', 'execute');
+        $execute->setAccessible(true);
+
+        $this->expectException('Ramsey\\Uuid\\Console\\Exception');
+        $this->expectExceptionMessage('Your version of ramsey/uuid don\'t support uuid6.');
+
+        $execute->invoke($generate, $input1, $output1);
+    }
+
+    /**
+     * @covers Ramsey\Uuid\Console\Command\GenerateCommand::execute
+     * @covers Ramsey\Uuid\Console\Command\GenerateCommand::createUuid
      * @covers Ramsey\Uuid\Console\Command\GenerateCommand::validateNamespace
      */
     public function testExecuteForUuidSpecifyVersion3WithDnsNs()
@@ -672,7 +786,7 @@ class GenerateCommandTest extends TestCase
 
         $generate = new GenerateCommand();
 
-        $input = new StringInput('6');
+        $input = new StringInput('7');
         $input->bind($generate->getDefinition());
 
         $output = new TestOutput();
@@ -681,7 +795,7 @@ class GenerateCommandTest extends TestCase
         $execute->setAccessible(true);
 
         $this->expectException('Ramsey\\Uuid\\Console\\Exception');
-        $this->expectExceptionMessage('Invalid UUID version. Supported are version "1", "3", "4", and "5".');
+        $this->expectExceptionMessage('Invalid UUID version. Supported are version "1", "3", "4", "5" and "6".');
 
         $execute->invoke($generate, $input, $output);
     }


### PR DESCRIPTION
## Description
Support generating uuid v6 if `ramsey/uuid` have it available 

## Motivation and context
I expected the cli version of the library to support all uuid version on the main class

## How has this been tested?
Full coverage by unit test

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] I have added tests to cover my changes.
