### PR TITLE
fix(component): Replace moontoast with brick/math

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
         "symfony/console": "^5.0 || ^6.0"
     },
     "require-dev": {
+        "brick/math": "^0.10",
         "captainhook/plugin-composer": "^5.3",
         "ergebnis/composer-normalize": "^2.28.3",
-        "moontoast/math": "^1.2",
         "php-parallel-lint/php-console-highlighter": "^1.0",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpcsstandards/phpcsutils": "^1.0.0-alpha4",


### PR DESCRIPTION
## Description

- Replace the `moontoast` with `brick/math` dependency.

## Motivation and context

- When running the `composer install` command, it presents the following error message:

```sh
......
Package moontoast/math is abandoned, you should avoid using it. Use brick/math instead.
......
```

## How has this been tested?

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Component fix

## PR checklist

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] I have added tests to cover my changes.
